### PR TITLE
Changed `ShippingRate.PhoneRequired` to `bool?` type

### DIFF
--- a/RechargeSharp/Entities/Shared/ShippingRate.cs
+++ b/RechargeSharp/Entities/Shared/ShippingRate.cs
@@ -63,7 +63,7 @@ namespace RechargeSharp.Entities.Shared
         public string Name { get; set; }
 
         [JsonProperty("phone_required")]
-        public bool PhoneRequired { get; set; }
+        public bool? PhoneRequired { get; set; }
 
         [JsonProperty("price")]
         public string Price { get; set; }


### PR DESCRIPTION
Changed `ShippingRate.PhoneRequired` to `bool?` type to account for possible null value returned from Recharge API.

![image](https://user-images.githubusercontent.com/87319620/125308068-9851cb80-e2fe-11eb-8614-038dff9913ce.png)

Fixes #15 