### PR TITLE
Changed `Checkout.ShippingRate` to `ShippingRate` type

### DIFF
--- a/RechargeSharp/Entities/Checkouts/Checkout.cs
+++ b/RechargeSharp/Entities/Checkouts/Checkout.cs
@@ -81,7 +81,7 @@ namespace RechargeSharp.Entities.Checkouts
         public ShippingLine ShippingLine { get; set; }
 
         [JsonProperty("shipping_rate")]
-        public List<ShippingRate> ShippingRate { get; set; }
+        public ShippingRate ShippingRate { get; set; }
 
         [JsonProperty("subtotal_price", NullValueHandling = NullValueHandling.Ignore)]
         public string SubtotalPrice { get; set; }


### PR DESCRIPTION
Changed `Checkout.ShippingRate` to `ShippingRate` type to account for a single object returned from the Recharge API instead of an array.

![image](https://user-images.githubusercontent.com/87319620/125463341-57dd3417-6013-487a-957e-cfae64f3174d.png)

Fixes #18 