### PR TITLE
Fix inability to deserialize Product json

### DIFF
--- a/RechargeSharp.Entities.Tests/RechargeSharp.Entities.Tests.csproj
+++ b/RechargeSharp.Entities.Tests/RechargeSharp.Entities.Tests.csproj
@@ -45,6 +45,9 @@
     <None Update="TestData\Address.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="TestData\Product.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/RechargeSharp.Entities.Tests/RechargeSharpSerializationTests.cs
+++ b/RechargeSharp.Entities.Tests/RechargeSharpSerializationTests.cs
@@ -854,6 +854,16 @@ namespace RechargeSharp.Entities.Tests
 
             Assert.Equal(sut, JsonConvert.DeserializeObject<Product>(jsonString));
         }
+        
+        [Theory]
+        [InlineAutoData]
+        public void CanDeserializeActualProductJsonTest()
+        {
+            var jsonString = TestDataHandler.GetProductString;
+            var deserialized = JsonConvert.DeserializeObject<Product>(jsonString);
+            Assert.NotNull(deserialized);
+            Assert.NotEqual(0, deserialized.Id);
+        }
 
         [Theory]
         [InlineAutoData]

--- a/RechargeSharp.Entities.Tests/TestData/Product.json
+++ b/RechargeSharp.Entities.Tests/TestData/Product.json
@@ -1,0 +1,33 @@
+{
+  "collection_id": null,
+  "created_at": "2022-09-12T06:39:18",
+  "discount_amount": 0E-10,
+  "discount_type": "percentage",
+  "handle": "test",
+  "id": 123,
+  "images": {
+    "large": "https://cdn.shopify.com/s/files/1/123/123/123/products/Test_large.png",
+    "medium": "https://cdn.shopify.com/s/files/1/123/123/123/products/Test_medium.png",
+    "original": "https://cdn.shopify.com/s/files/1/123/123/123/products/Test.png",
+    "small": "https://cdn.shopify.com/s/files/1/123/123/123/products/Test_small.png"
+  },
+  "product_id": 123123,
+  "shopify_product_id": 123123,
+  "subscription_defaults": {
+    "charge_interval_frequency": 30,
+    "cutoff_day_of_month": null,
+    "cutoff_day_of_week": null,
+    "expire_after_specific_number_of_charges": null,
+    "modifiable_properties": [],
+    "number_charges_until_expiration": null,
+    "order_day_of_month": null,
+    "order_day_of_week": null,
+    "order_interval_frequency_options": [
+      "30"
+    ],
+    "order_interval_unit": "day",
+    "storefront_purchase_options": "subscription_and_onetime"
+  },
+  "title": "Test product",
+  "updated_at": "2022-09-12T09:10:01"
+}

--- a/RechargeSharp.Entities.Tests/Utilities/TestDataHandler.cs
+++ b/RechargeSharp.Entities.Tests/Utilities/TestDataHandler.cs
@@ -17,5 +17,7 @@ namespace RechargeSharp.Entities.Tests.Utilities
         public static string GetTestAddressString => File.ReadAllText(TestDataPaths.Address);
         public static string GetTestAddressOffsetString => File.ReadAllText(TestDataPaths.AddressOffset);
         public static string GetTestAddressUTCString => File.ReadAllText(TestDataPaths.AddressUTC);
+        
+        public static string GetProductString => File.ReadAllText(TestDataPaths.Product);
     }
 }

--- a/RechargeSharp.Entities.Tests/Utilities/TestDataPaths.cs
+++ b/RechargeSharp.Entities.Tests/Utilities/TestDataPaths.cs
@@ -9,5 +9,6 @@ namespace RechargeSharp.Entities.Tests.Utilities
         public static string Address => Path.Join(BasePath, "Address.json");
         public static string AddressUTC => Path.Join(BasePath, "AddressUTC.json");
         public static string AddressOffset => Path.Join(BasePath, "AddressOffset.json");
+        public static string Product => Path.Join(BasePath, "Product.json");
     }
 }

--- a/RechargeSharp.Entities/Entities/Checkouts/CreateCheckoutRequestLineItem.cs
+++ b/RechargeSharp.Entities/Entities/Checkouts/CreateCheckoutRequestLineItem.cs
@@ -9,7 +9,7 @@ namespace RechargeSharp.Entities.Checkouts
         {
             if (other is null) return false;
             if (ReferenceEquals(this, other)) return true;
-            return ChargeIntervalFrequency == other.ChargeIntervalFrequency && CutoffDayOfMonth == other.CutoffDayOfMonth && CutoffDayOfWeek == other.CutoffDayOfWeek && ExpireAfterSpecificNumberOfCharges == other.ExpireAfterSpecificNumberOfCharges && FulfillmentService == other.FulfillmentService && Grams == other.Grams && LinePrice == other.LinePrice && OrderDayOfMonth == other.OrderDayOfMonth && OrderDayOfWeek == other.OrderDayOfWeek && OrderIntervalFrequency == other.OrderIntervalFrequency && OrderIntervalUnit == other.OrderIntervalUnit && Price == other.Price && ProductId == other.ProductId && Quantity == other.Quantity && RequiresShipping == other.RequiresShipping && Sku == other.Sku && Taxable == other.Taxable && Title == other.Title && VariantId == other.VariantId && VariantTitle == other.VariantTitle && Vendor == other.Vendor;
+            return ChargeIntervalFrequency == other.ChargeIntervalFrequency && CutoffDayOfMonth == other.CutoffDayOfMonth && CutoffDayOfWeek == other.CutoffDayOfWeek && ExpireAfterSpecificNumberOfCharges == other.ExpireAfterSpecificNumberOfCharges && FirstRecurringChargeDelay == other.FirstRecurringChargeDelay && FulfillmentService == other.FulfillmentService && Grams == other.Grams && LinePrice == other.LinePrice && OrderDayOfMonth == other.OrderDayOfMonth && OrderDayOfWeek == other.OrderDayOfWeek && OrderIntervalFrequency == other.OrderIntervalFrequency && OrderIntervalUnit == other.OrderIntervalUnit && Price == other.Price && ProductId == other.ProductId && Quantity == other.Quantity && RequiresShipping == other.RequiresShipping && Sku == other.Sku && Taxable == other.Taxable && Title == other.Title && VariantId == other.VariantId && VariantTitle == other.VariantTitle && Vendor == other.Vendor;
         }
 
         public override bool Equals(object? obj)
@@ -27,6 +27,7 @@ namespace RechargeSharp.Entities.Checkouts
             hash.Add(CutoffDayOfMonth);
             hash.Add(CutoffDayOfWeek);
             hash.Add(ExpireAfterSpecificNumberOfCharges);
+            hash.Add(FirstRecurringChargeDelay);
             hash.Add(FulfillmentService);
             hash.Add(Grams);
             hash.Add(LinePrice);
@@ -69,6 +70,9 @@ namespace RechargeSharp.Entities.Checkouts
 
         [JsonProperty("expire_after_specific_number_of_charges", NullValueHandling = NullValueHandling.Ignore)]
         public long? ExpireAfterSpecificNumberOfCharges { get; set; }
+        
+        [JsonProperty("first_recurring_charge_delay", NullValueHandling = NullValueHandling.Ignore)]
+        public long? FirstRecurringChargeDelay { get; set; }
 
         [JsonProperty("fulfillment_service", NullValueHandling = NullValueHandling.Ignore)]
         public string? FulfillmentService { get; set; }

--- a/RechargeSharp.Entities/Entities/Products/Product.cs
+++ b/RechargeSharp.Entities/Entities/Products/Product.cs
@@ -50,7 +50,7 @@ namespace RechargeSharp.Entities.Products
         }
 
         [JsonProperty("collection_id")]
-        public long CollectionId { get; set; }
+        public long? CollectionId { get; set; }
 
         [JsonProperty("created_at")]
         public DateTimeOffset CreatedAt { get; set; }

--- a/RechargeSharp.Entities/Entities/Products/ProductSubscriptionDefaults.cs
+++ b/RechargeSharp.Entities/Entities/Products/ProductSubscriptionDefaults.cs
@@ -50,28 +50,28 @@ namespace RechargeSharp.Entities.Products
         public long ChargeIntervalFrequency { get; set; }
 
         [JsonProperty("cutoff_day_of_month")]
-        public long CutoffDayOfMonth { get; set; }
+        public long? CutoffDayOfMonth { get; set; }
 
         [JsonProperty("cutoff_day_of_week")]
-        public long CutoffDayOfWeek { get; set; }
+        public long? CutoffDayOfWeek { get; set; }
 
         [JsonProperty("expire_after_specific_number_of_charges")]
-        public long ExpireAfterSpecificNumberOfCharges { get; set; }
+        public long? ExpireAfterSpecificNumberOfCharges { get; set; }
 
         [JsonProperty("handle")]
         public string? Handle { get; set; }
 
         [JsonProperty("number_charges_until_expiration")]
-        public long NumberChargesUntilExpiration { get; set; }
+        public long? NumberChargesUntilExpiration { get; set; }
 
         [JsonProperty("order_day_of_month")]
-        public long OrderDayOfMonth { get; set; }
+        public long? OrderDayOfMonth { get; set; }
 
         [JsonProperty("order_day_of_week")]
         public string? OrderDayOfWeek { get; set; }
 
         [JsonProperty("order_interval_frequency")]
-        public long OrderIntervalFrequency { get; set; }
+        public long? OrderIntervalFrequency { get; set; }
 
         [JsonProperty("order_interval_frequency_options")]
         public IEnumerable<long>? OrderIntervalFrequencyOptions { get; set; }


### PR DESCRIPTION
The current lack of nullability on some Product properties prevents deserialization of real-life responses from the Recharge API.
This PR fixes that for the included example JSON